### PR TITLE
GR2: Add test_sound and E3 levels

### DIFF
--- a/patches/xml/GravityDaze2-Orbis.xml
+++ b/patches/xml/GravityDaze2-Orbis.xml
@@ -516,6 +516,28 @@
             <Line Type="utf8" Address="0x001b08075" Value="Test test_hud_select"/>
         </PatchList>
     </Metadata>
+        <Metadata Title="Gravity Rush 2 (Gravity Daze 2)"
+              Name="Load hidden Level test_sound"
+              Note="Needs 'Print+DebugPrint Fixes' patch for working menu"
+              Author="illusion"
+              PatchVer="1.0"
+              AppVer="01.11"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="utf8" Address="0x001b08075" Value="TestSound test_sound"/>
+        </PatchList>
+    </Metadata>
+    <Metadata Title="Gravity Rush 2 (Gravity Daze 2)"
+              Name="Load hidden Level root_E3"
+              Note="Needs 'Print+DebugPrint Fixes' patch for working menu"
+              Author="illusion"
+              PatchVer="1.0"
+              AppVer="01.11"
+              AppElf="eboot.bin">
+        <PatchList>
+            <Line Type="utf8" Address="0x001b08075" Value="LaunchScript root_E3"/>
+        </PatchList>
+    </Metadata>
     <Metadata Title="Gravity Rush 2 (Gravity Daze 2)"
               Name="Force Region (ENABLE FIRST)"
               Author="illusion"


### PR DESCRIPTION
AFAIK both levels cannot be accessed through test_hud_select, so I copied that cheat and just changed it to the right level using info from Hidden Palace's GR2 page. I basically only want this merged so that I can use GoldHEN cheats manager to update the patches and not have to manually readd this modified one lol